### PR TITLE
Replace deprecated calls to wait_ms API

### DIFF
--- a/drivers/HX8357D/HX8357D.cpp
+++ b/drivers/HX8357D/HX8357D.cpp
@@ -18,7 +18,7 @@
 #include "HX8357D.h"
 #include "hx8357d_registers.h"
 
-#include "platform/mbed_wait_api.h"
+#include "rtos/ThisThread.h"
 
 void HX8357D::init(void) {
 
@@ -26,10 +26,10 @@ void HX8357D::init(void) {
 
 	// Issue a soft reset and wait a moment
 	this->reset();
-	wait_ms(10);
+	rtos::ThisThread::sleep_for(10);
 
 	this->set_extc();
-	wait_ms(10);
+	rtos::ThisThread::sleep_for(10);
 
 	// Set RGB
 	buffer[0] = 0;
@@ -88,10 +88,10 @@ void HX8357D::init(void) {
 	// TEARLINE(0x00, 0x02)
 	// SLPOUT
 	this->exit_sleep_mode();
-	wait_ms(150);
+	rtos::ThisThread::sleep_for(150);
 
 	this->display_on();
-	wait_ms(50);
+	rtos::ThisThread::sleep_for(50);
 }
 
 void HX8357D::reset(void) {

--- a/drivers/noritake-vfd-gud900/NoritakeVFD.cpp
+++ b/drivers/noritake-vfd-gud900/NoritakeVFD.cpp
@@ -17,7 +17,7 @@
 
 #include "NoritakeVFD.h"
 
-#include "platform/mbed_wait_api.h"
+#include "rtos/ThisThread.h"
 
 NoritakeVFD::NoritakeVFD(DisplayInterface& interface,
 		PinName reset, uint32_t height, uint32_t width) :
@@ -50,7 +50,7 @@ void NoritakeVFD::reset(void) {
 	if(_reset != NULL) {
 		// Pulse reset low
 		*_reset = 0;
-		wait_ms(2);
+		rtos::ThisThread::sleep_for(2);
 		*_reset = 1;
 	}
 }


### PR DESCRIPTION
The `wait_ms` API has been deprecated in Mbed and removed from master at time of writing. To continue to be compatible with future releases of Mbed-OS, I have replaced any calls to `wait_ms` with the recommended `rtos::ThisThread::sleep_for`.

I'm not sure if this has any implications for a baremetal build, but I think Mbed retargets this `rtos::ThisThread:sleep_for` in the case where there is no RTOS. 

Regardless, most users of mbed-lvgl and uDisplay will probably have an RTOS and so we will fix baremetal compatibility if it becomes something that is requested.